### PR TITLE
Add logic to handle empty Query part in callback URLs

### DIFF
--- a/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
+++ b/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
@@ -93,6 +93,7 @@ namespace DotNetOpenAuth.GoogleOAuth2
         protected override Uri GetServiceLoginUrl(Uri returnUrl)
         {
             var scopes = _requestedScopes.Select(x => !x.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? ScopeBaseUri + x : x);
+            var state = string.IsNullOrEmpty(returnUrl.Query) ? string.Empty : returnUrl.Query.Substring(1);
 
             return BuildUri(AuthorizationEndpoint, new NameValueCollection
                 {
@@ -100,7 +101,7 @@ namespace DotNetOpenAuth.GoogleOAuth2
                     { "client_id", _clientId },
                     { "scope", string.Join(" ", scopes) },
                     { "redirect_uri", returnUrl.GetLeftPart(UriPartial.Path) },
-                    { "state", returnUrl.Query.Substring(1) },
+                    { "state", state },
                 });
         }
 


### PR DESCRIPTION
Fix for https://github.com/mj1856/DotNetOpenAuth.GoogleOAuth2/issues/4
