### PR TITLE
Feature reflection permission not required

### DIFF
--- a/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
+++ b/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
@@ -157,7 +157,7 @@ namespace DotNetOpenAuth.GoogleOAuth2
                     break;
                 string key = mainBlock.Substring(quoteLoc1 + 1, quoteLoc2 - quoteLoc1 - 1);
                 mainBlock = mainBlock.Substring(quoteLoc2 + 1);
-                mainBlock = mainBlock.TrimStart(" :".ToCharArray());
+                mainBlock = mainBlock.TrimStart(" :\r\n\t".ToCharArray());
                 if (mainBlock.StartsWith("\""))// Has quotation marks on value;
                 {
                     quoteLoc1 = mainBlock.IndexOf('\"', 0);
@@ -174,10 +174,10 @@ namespace DotNetOpenAuth.GoogleOAuth2
                 {
                     int commaLoc = mainBlock.IndexOf(',', 0);
                     if (commaLoc == -1)
-                        break;
-                    string value = mainBlock.Substring(0, commaLoc).Trim(" ".ToCharArray());
+                        commaLoc = mainBlock.Length;
+                    string value = mainBlock.Substring(0, commaLoc).Trim(" \r\n\t".ToCharArray());
                     dictionary.Add(key, value);
-                    mainBlock = mainBlock.Substring(commaLoc + 1);
+                    mainBlock = mainBlock.Substring(commaLoc);
                 }
             }
             return dictionary;

--- a/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
+++ b/DotNetOpenAuth.GoogleOAuth2/GoogleOAuth2Client.cs
@@ -120,10 +120,67 @@ namespace DotNetOpenAuth.GoogleOAuth2
                 using (var textReader = new StreamReader(stream))
                 {
                     var json = textReader.ReadToEnd();
-                    var extraData = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
+                    var extraData = new Dictionary<string, string>();
+                    try
+                    {
+                        extraData = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Perhaps the ReflectionPermission has not been enabled on the Web app;
+                        // Try using an alternative method of parsing to convert the JSON into
+                        // a Dictionary<string, string>:
+                        extraData = JsonToDictionary(json);
+                    }
                     return extraData;
                 }
             }
+        }
+
+        protected Dictionary<string, string> JsonToDictionary(string json)
+        {
+            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+            int braceLoc1 = json.IndexOf("{", 0);
+            if (braceLoc1 == -1)
+                return dictionary;
+            int braceLoc2 = json.IndexOf("}", braceLoc1);
+            if (braceLoc2 == -1)
+                return dictionary;
+            string mainBlock = json.Substring(braceLoc1 + 1, braceLoc2 - braceLoc1 - 1);
+            while (mainBlock.Length > 0)
+            {
+                int quoteLoc1 = mainBlock.IndexOf('\"', 0);
+                if (quoteLoc1 == -1)
+                    break;
+                int quoteLoc2 = mainBlock.IndexOf('\"', quoteLoc1 + 1);
+                if (quoteLoc2 == -1)
+                    break;
+                string key = mainBlock.Substring(quoteLoc1 + 1, quoteLoc2 - quoteLoc1 - 1);
+                mainBlock = mainBlock.Substring(quoteLoc2 + 1);
+                mainBlock = mainBlock.TrimStart(" :".ToCharArray());
+                if (mainBlock.StartsWith("\""))// Has quotation marks on value;
+                {
+                    quoteLoc1 = mainBlock.IndexOf('\"', 0);
+                    if (quoteLoc1 == -1)
+                        break;
+                    quoteLoc2 = mainBlock.IndexOf('\"', quoteLoc1 + 1);
+                    if (quoteLoc2 == -1)
+                        break;
+                    string value = mainBlock.Substring(quoteLoc1 + 1, quoteLoc2 - quoteLoc1 - 1);
+                    dictionary.Add(key, value);
+                    mainBlock = mainBlock.Substring(quoteLoc2 + 1);
+                }
+                else// Has bare value (no quotation marks);
+                {
+                    int commaLoc = mainBlock.IndexOf(',', 0);
+                    if (commaLoc == -1)
+                        break;
+                    string value = mainBlock.Substring(0, commaLoc).Trim(" ".ToCharArray());
+                    dictionary.Add(key, value);
+                    mainBlock = mainBlock.Substring(commaLoc + 1);
+                }
+            }
+            return dictionary;
         }
 
         protected override string QueryAccessToken(Uri returnUrl, string authorizationCode)


### PR DESCRIPTION
When I found this project, I tried using it in a security-restricted application, but the JsonConvert.DeserializeObject() kept getting an exception saying the request for ReflectionPermission had failed. Since security is very important to me, I decided to expand the parsing code to better handle the case when the DeserializeObject() function gets an exception. When this happens, it will try an alternative method which uses a function I just wrote to manually parse the JSON into a string dictionary. While I am not positive the function handles all possible cases, I was pretty careful with the logic, and I certainly did test it with various strings to make sure nothing is obviously wrong with it. A key thing to note here is that this new function comes into effect *only* if the original approach gets an exception. Hence, for those users with ReflectionPermission enabled, there should be no functional or performance difference whatsoever.